### PR TITLE
vimlint var scoping, skip comments when parsing properties

### DIFF
--- a/autoload/editorconfig/local_vimrc.vim
+++ b/autoload/editorconfig/local_vimrc.vim
@@ -3,9 +3,9 @@ scriptencoding utf-8
 " vimscript {{{1
 
 function! editorconfig#local_vimrc#execute(value) abort
-  let path = fnamemodify(a:value, ':p')
+  let l:path = fnamemodify(a:value, ':p')
 
-  if filereadable(path)
+  if filereadable(l:path)
     source `=path`
   else
     if get(g:, 'editorconfig_verbose', 0)


### PR DESCRIPTION
Fixed:

- plugin tries to parse comments as properties (parse_properties assumes the line is a property if it is not a file format)
- also scoped some vars to function local

Here's an .editorconfig file that triggers such errors:
https://github.com/gnunn1/terminix/blob/master/.editorconfig
