### PR TITLE
Fix trimming of empty comments

### DIFF
--- a/autoload/editorconfig.vim
+++ b/autoload/editorconfig.vim
@@ -203,9 +203,11 @@ endfunction "}}}
 "
 " >>> echo s:remove_comment('bar')
 " bar
+" >>> echo s:remove_comment('#')
+"
 
 function! s:remove_comment(line) abort "{{{
-  let pos = match(a:line, '\s*[;#].\+')
+  let pos = match(a:line, '\s*[;#].*')
   return pos == -1 ? a:line : pos == 0 ? '' : a:line[: pos-1]
 endfunction "}}}
 


### PR DESCRIPTION
For example this .editorconfig:

```
# 

root = true
```

is parsed incorrectly:

s:parse_properties(...)  -> [], {}
  s:trim(...)  -> ['#', 'root = true']
    s:remove_comment('#')  -> '#'

This commit fixes this issue.

- - -

IIRC INI files allow `;` and `#` inside value (e.g. `something = foo; bar`), so `s:remove_comment()` is still wrong.