### PR TITLE
Use execute 'source ' . path instead of the backtick expansion

### DIFF
--- a/autoload/editorconfig/local_vimrc.vim
+++ b/autoload/editorconfig/local_vimrc.vim
@@ -6,7 +6,7 @@ function! editorconfig#local_vimrc#execute(value) abort
   let path = fnamemodify(a:value, ':p')
 
   if filereadable(path)
-    source `=path`
+    execute 'source ' . path
   else
     if get(g:, 'editorconfig_verbose', 0)
       echoerr printf('editorconfig: unable to load: vimscript=%s', a:value)


### PR DESCRIPTION
Backtick expansion is fancy, but this construct actually works.

Fixes #18 
