### PR TITLE
Fix 'editroconfig' spelling

### DIFF
--- a/autoload/editorconfig/insert_final_newline.vim
+++ b/autoload/editorconfig/insert_final_newline.vim
@@ -24,7 +24,7 @@ function! s:bool(value) abort "{{{
   elseif a:value is# 'false'
     return 0
   elseif get(g:, 'editorconfig_verbose', 0)
-    echoerr printf('editroconfig: unsupported value: insert_final_newline=%s', a:value)
+    echoerr printf('editorconfig: unsupported value: insert_final_newline=%s', a:value)
   endif
 endfunction "}}}
 

--- a/autoload/editorconfig/max_line_length.vim
+++ b/autoload/editorconfig/max_line_length.vim
@@ -17,7 +17,7 @@ function! editorconfig#max_line_length#execute(value) abort
     " So, this elseif is here only to accept value 'off' and not
     " complain about it.
   elseif get(g:, 'editorconfig_verbose', 0)
-    echoerr printf('editroconfig: unsupported value: max_line_length=%s', a:value)
+    echoerr printf('editorconfig: unsupported value: max_line_length=%s', a:value)
   endif
 endfunction
 " 1}}}

--- a/autoload/editorconfig/spell_enabled.vim
+++ b/autoload/editorconfig/spell_enabled.vim
@@ -7,6 +7,6 @@ function! editorconfig#spell_enabled#execute(value) abort
   elseif a:value is# 'false'
     setlocal nospell
   elseif get(g:, 'editorconfig_verbose', 0)
-    echoerr printf('editroconfig: unsupported value: spell_enabled=%s', a:value)
+    echoerr printf('editorconfig: unsupported value: spell_enabled=%s', a:value)
   endif
 endfunction

--- a/autoload/editorconfig/trim_trailing_whitespace.vim
+++ b/autoload/editorconfig/trim_trailing_whitespace.vim
@@ -18,7 +18,7 @@ function! editorconfig#trim_trailing_whitespace#execute(value) abort
     autocmd plugin-editorconfig-local BufWritePre <buffer> call s:do_trim_trailing_whitespace()
   elseif a:value is# 'false'
   elseif get(g:, 'editorconfig_verbose', 0)
-    echoerr printf('editroconfig: unsupported value: trim_trailing_whitespace=%s', a:value)
+    echoerr printf('editorconfig: unsupported value: trim_trailing_whitespace=%s', a:value)
   endif
 endfunction
 


### PR DESCRIPTION
Noticed this small mistake reading through PRs.