### PR TITLE
Fix a problem that charset "utf-8-bom" doesn't work

### DIFF
--- a/autoload/editorconfig/charset.vim
+++ b/autoload/editorconfig/charset.vim
@@ -13,11 +13,11 @@ scriptencoding utf-8
 
 function! editorconfig#charset#execute(value) abort
   " encoding
-  if type(a:value) == type("") && a:value !~ '|'
-    sandbox execute 'setlocal fileencoding=' . a:value
-  elseif a:value is? 'utf-8-bom'
+  if a:value is? 'utf-8-bom'
     setlocal fileencoding=utf-8
     setlocal bomb
+  elseif type(a:value) == type("") && a:value !~ '|'
+    sandbox execute 'setlocal fileencoding=' . a:value
   elseif get(g:, 'editorconfig_verbose', 0)
     echoerr printf('editorconfig: unsupported value: charset=%s', a:value)
   endif


### PR DESCRIPTION
When "charset: utf-8-bom" is written is .editorconfig, invalid command `setlocal fileencoding=utf-8-bom` is executed. It seems that the order of if ... elseif is incorrect.