### PR TITLE
Allow dialects

### DIFF
--- a/autoload/editorconfig/spell_language.vim
+++ b/autoload/editorconfig/spell_language.vim
@@ -26,7 +26,9 @@ function! editorconfig#spell_language#execute(value) abort
 endfunction
 
 function! s:lang_available(value) abort "{{{
-  return !empty(filter(copy(s:languages), 'stridx(v:val, a:value) == 0'))
+  " We need to accept even dialects of languages, e.g., en_gb
+  let lang = split(a:value, '_')[0]
+  return !empty(filter(copy(s:languages), 'stridx(v:val, lang) == 0'))
 endfunction "}}}
 
 let s:languages = map(filter(globpath(&runtimepath, 'spell/*', 1, 1), '!isdirectory(v:val)'), 'fnamemodify(v:val, '':t'')')


### PR DESCRIPTION
vim option ``spelllang`` accepts (and uses) not only languages, but its dialects as well, so for example it is possible to have ``en_gb`` language. Unfortunately, those dialects are not provided in the generated variable ``s:languages``, so we need to make sure when checking for its presence that dialect is removed.