### PR TITLE
Trim root path from filepath if it's set

### DIFF
--- a/autoload/editorconfig.vim
+++ b/autoload/editorconfig.vim
@@ -25,6 +25,9 @@ function! editorconfig#load() abort
     return
   endif
   let rule = s:scan(fnamemodify(filepath, ':h'))
+  if len(rule) > 0 && has_key(rule[0][1], 'root')
+    let filepath = s:trim_root(filepath, rule[0][1]['root'])
+  endif
   let props = s:filter_matched(rule, filepath)
   if empty(props) | return | endif
   call s:fill_defaults(props)
@@ -172,6 +175,13 @@ function! s:parse_properties(lines) abort "{{{
 
   endfor
   return [a:lines[i+1 :], _]
+endfunction "}}}
+
+function! s:trim_root(filepath, root) abort "{{{
+  if stridx(a:filepath, a:root) == 0
+    return strpart(a:filepath, len(a:root))
+  endif
+  return a:filepath
 endfunction "}}}
 
 let s:defaults = {'tab_width': 'indent_size'}


### PR DESCRIPTION
Fix #20.

This trims the root path from filepath. Since the root is set, we don't care about the parent path as it shouldn't be a part of match.

The `rule[0][1]['root']` is a result of `%:h` modifier, so `root` doesn't have a trailing path separator. So if filepath starts with `root`, the result of `s:trim_root()` can be:
- a path separator (the `root` itself)
- a string starts with a path separator (some file or directory under the `root`)