### PR TITLE
Don't add trim trailing whitespace regex to search pattern history.

### DIFF
--- a/autoload/editorconfig/trim_trailing_whitespace.vim
+++ b/autoload/editorconfig/trim_trailing_whitespace.vim
@@ -25,7 +25,7 @@ endfunction
 function! s:do_trim_trailing_whitespace() abort "{{{
   let view = winsaveview()
   try
-    %s/\s\+$//e
+    keeppatterns %s/\s\+$//e
   finally
     call winrestview(view)
   endtry


### PR DESCRIPTION
Fixes #35